### PR TITLE
fixed issue with missing prefix in regexp_to_df

### DIFF
--- a/R/parsedate-package.r
+++ b/R/parsedate-package.r
@@ -151,7 +151,7 @@ regexp_to_df <- function(text, match) {
   lapply(seq_len(sum(positive)), function(i) {
     data.frame(start = g_start[i,],
                length = g_length[i,],
-               match = substring(text[i], g_start[i,],
+               match = substring(g_text[i], g_start[i,],
                  g_start[i,] + g_length[i,] - 1),
                stringsAsFactors = FALSE)
   })


### PR DESCRIPTION
I encountered the following issue when parsing vectors with missing values:

> library(parsedate)
> dates <- c("", "1985-09-02T12:00:00", "1973-07-13T12:00:00")
> parse_iso_8601(dates)
[1] NA                        NA                        "1985-09-02 12:00:00 UTC"